### PR TITLE
Add tracking option id for Purchase Orders

### DIFF
--- a/lib/xeroizer/models/tracking_category_child.rb
+++ b/lib/xeroizer/models/tracking_category_child.rb
@@ -13,6 +13,7 @@ module Xeroizer
       string  :name
       string  :option
       guid    :tracking_category_id
+      guid    :tracking_option_id
       
     end
     


### PR DESCRIPTION
Why:

This field is passed from Xero, we just need it listed in the
model to be able to access it.